### PR TITLE
Upgrade to Prism 8.0

### DIFF
--- a/Core/Core.csproj
+++ b/Core/Core.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.Wpf" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="8.0.0.1909" />
+    <PackageReference Include="Prism.Wpf" Version="8.0.0.1909" />
   </ItemGroup>
 
 </Project>

--- a/Core/Utility/BaseViewModel.cs
+++ b/Core/Utility/BaseViewModel.cs
@@ -1,6 +1,6 @@
-﻿using CommonServiceLocator;
-using Prism;
+﻿using Prism;
 using Prism.Events;
+using Prism.Ioc;
 using Prism.Mvvm;
 using Prism.Regions;
 using Prism.Services.Dialogs;
@@ -24,13 +24,13 @@ namespace Core
 
         protected BaseViewModel()
         {
-            _messageBoxService = ServiceLocator.Current.GetInstance<IMessageBoxService>();
-            _fileDialogService = ServiceLocator.Current.GetInstance<IFileDialogService>();
-            _logService = ServiceLocator.Current.GetInstance<ILogService>();
+            _messageBoxService = ContainerLocator.Current.Resolve<IMessageBoxService>();
+            _fileDialogService = ContainerLocator.Current.Resolve<IFileDialogService>();
+            _logService = ContainerLocator.Current.Resolve<ILogService>();
 
-            _dialogService = ServiceLocator.Current.GetInstance<IDialogService>();
-            _regionManager = ServiceLocator.Current.GetInstance<IRegionManager>();
-            _aggregator = ServiceLocator.Current.GetInstance<IEventAggregator>();
+            _dialogService = ContainerLocator.Current.Resolve<IDialogService>();
+            _regionManager = ContainerLocator.Current.Resolve<IRegionManager>();
+            _aggregator = ContainerLocator.Current.Resolve<IEventAggregator>();
         }
 
         protected void ShowParameterNullError([CallerMemberName] string callerName = null)

--- a/Modules/CommonServicesModule/CommonServicesModule.csproj
+++ b/Modules/CommonServicesModule/CommonServicesModule.csproj
@@ -6,10 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommonServiceLocator" Version="2.0.5" />
-    <PackageReference Include="NLog" Version="4.7.4" />
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.Wpf" Version="7.2.0.1422" />
+    <PackageReference Include="NLog" Version="4.7.5" />
+    <PackageReference Include="Prism.Core" Version="8.0.0.1909" />
+    <PackageReference Include="Prism.Wpf" Version="8.0.0.1909" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Modules/MainModule/MainModule.csproj
+++ b/Modules/MainModule/MainModule.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="8.0.0.1909" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Shell/Shell.csproj
+++ b/Shell/Shell.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.Unity" Version="7.2.0.1422" />
-    <PackageReference Include="Prism.Wpf" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="8.0.0.1909" />
+    <PackageReference Include="Prism.Unity" Version="8.0.0.1909" />
+    <PackageReference Include="Prism.Wpf" Version="8.0.0.1909" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgraded to Prism Framework 8.0

Breaking changes in 8.0

* `CommonServiceLocator` was replaced with `ContainerLocator`.
* `prism:ViewModelLocator.AutoWireViewModel="True"` not needed anymore; but this feature doesn't work because there is a bug in latest stable release.